### PR TITLE
fix violin labels

### DIFF
--- a/src/app/tf/[species]/[factor]/geneexpression/geneexpression.tsx
+++ b/src/app/tf/[species]/[factor]/geneexpression/geneexpression.tsx
@@ -231,10 +231,18 @@ const GeneExpressionPage: React.FC<GeneExpressionPageProps> = (props) => {
         ? tissueColors[tissue]
         : tissueColors.missing;
 
-      const label = key
-        .replace(/-positive/gi, "+")
-        .replace(/alpha-beta/gi, "αβ")
-        .replace(/,/gi, "");
+      let label;
+      if (key.includes(",")) {
+        const [first, rest] = key.split(",", 2);
+        label = rest.includes("alpha-beta")
+          ? `${first},${rest.replace(/alpha-beta/gi, "αβ")}`
+          : first;
+      } else {
+        label = key
+          .replace(/-positive/gi, "+")
+          .replace(/alpha-beta/gi, "αβ")
+          .replace(/ \(in vitro differentiated cells\)/gi, "")
+      }
 
       const data: ViolinPoint<DataPoint>[] = values.map((value, i) => {
         const metadata: DataPoint = {


### PR DESCRIPTION
- new query returns full biosample name, fixed violin labels to be split after the cell type is said
- kept alpha/beta cells, since they were displayed before the change